### PR TITLE
Updated version of browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livedocs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "REST API documentation generator",
   "main": "generate-markup.js",
   "scripts": {
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "adstream-adbank-api-generate-hash": "^1.0.0",
-    "browserify": "~3.18.0",
+    "browserify": "~12.0.1",
     "grunt-browserify2": "~0.1.8",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-nodemon": "~0.2.1",


### PR DESCRIPTION
version 3 had a dependency that could no longer be met on NPM